### PR TITLE
bug fix for custom connector check

### DIFF
--- a/internal/client/integrations/integrations.go
+++ b/internal/client/integrations/integrations.go
@@ -1454,10 +1454,11 @@ func getIntegrationConnection(connectionName eventparameter,
 
 	ic.Version = strings.Split(*connectionVersion.Value.StringValue, "/")[9]
 	connectionType := strings.Split(*connectionVersion.Value.StringValue, "/")[5]
-	if connectionType == "gcp" {
-		ic.CustomConnection = false
-	} else {
+	// CustomConnector will have the provider as customConnector. For others the provider can be default/GCP or any other provider.
+	if strings.EqualFold(connectionType, "customConnector") {
 		ic.CustomConnection = true
+	} else {
+		ic.CustomConnection = false
 	}
 	return ic
 }


### PR DESCRIPTION
After discussion with the Connectors team, it seem the right way to identify a custom connector is by checking the provider should `customConnector`. Hence we are now checking for the `customConnector` and all other providers will not be custom connectors. Below is some of common provider for connectors 
 * gcp
 * microsoft
 * default
 etc.