### PR TITLE
Add the OAuth2ResourceOwnerCredentials type to the AuthConfig.DecryptedCredential definition

### DIFF
--- a/internal/client/authconfigs/authconfigs.go
+++ b/internal/client/authconfigs/authconfigs.go
@@ -56,12 +56,13 @@ type authConfigExternal struct {
 }
 
 type decryptedCredential struct {
-	CredentialType            string                     `json:"credentialType,omitempty"`
-	UsernameAndPassword       *usernameAndPassword       `json:"usernameAndPassword,omitempty"`
-	OidcToken                 *oidcToken                 `json:"oidcToken,omitempty"`
-	Jwt                       *jwt                       `json:"jwt,omitempty"`
-	ServiceAccountCredentials *serviceAccountCredentials `json:"serviceAccountCredentials,omitempty"`
-	AuthToken                 *authToken                 `json:"authToken,omitempty"`
+	CredentialType                 string                           `json:"credentialType,omitempty"`
+	UsernameAndPassword            *usernameAndPassword             `json:"usernameAndPassword,omitempty"`
+	OidcToken                      *oidcToken                       `json:"oidcToken,omitempty"`
+	Jwt                            *jwt                             `json:"jwt,omitempty"`
+	ServiceAccountCredentials      *serviceAccountCredentials       `json:"serviceAccountCredentials,omitempty"`
+	AuthToken                      *authToken                       `json:"authToken,omitempty"`
+	OAuth2ResourceOwnerCredentials *oauth2ResourceOwnerCredentials  `json:"oauth2ResourceOwnerCredentials,omitempty"`
 }
 
 type usernameAndPassword struct {
@@ -88,6 +89,16 @@ type serviceAccountCredentials struct {
 type authToken struct {
 	Type  string `json:"type,omitempty"`
 	Token string `json:"token,omitempty"`
+}
+
+type oauth2ResourceOwnerCredentials struct {
+	ClientId      string `json:"clientId,omitempty"`
+	ClientSecret  string `json:"clientSecret,omitempty"`
+	Username      string `json:"username,omitempty"`
+	Password      string `json:"password,omitempty"`
+	TokenEndpoint string `json:"tokenEndpoint,omitempty"`
+	RequestType   string `json:"requestType,omitempty"`
+	Scope         string `json:"scope,omitempty"`
 }
 
 // Create


### PR DESCRIPTION
This PR closes #276 

Currently the `AuthConfig.DecryptedCredential` definition doesn't include configuration for `OAuth2ResourceOwnerCredentials` credential type. We can create a file with the needed fields and set the type to be `OAuth2ResourceOwnerCredentials` and it successfully creates an auth profile but the solution feels hacky because the type is missing in the definitions.

Adding the `OAuth2ResourceOwnerCredentials` credential type and its fields will keep the source code consistent.