### PR TITLE
feat: add label field to connection

### DIFF
--- a/internal/client/connections/connectors.go
+++ b/internal/client/connections/connectors.go
@@ -40,6 +40,7 @@ type listconnections struct {
 
 type connection struct {
 	Name                   *string             `json:"name,omitempty"`
+	Labels                 *map[string]string  `json:"labels,omitempty"`
 	Description            string              `json:"description,omitempty"`
 	ConnectorVersion       *string             `json:"connectorVersion,omitempty"`
 	ConnectorDetails       *connectorDetails   `json:"connectorDetails,omitempty"`


### PR DESCRIPTION

- This PR adds the capability to download connection labels when scaffolding.
- Since `connectionRequest` already has this field, I believe no more changes are warranted.
- Close #378
- Let me know if I need to change anything 😄 

---

Sidenote: To locally build and test this, I had to make the following change to the Dockerfile:

```diff
- FROM us-docker.pkg.dev/appintegration-toolkit/internal/jq:latest@sha256:d3a1c8a88f9223eab96bda760efab08290d274249581d2db6db010cbe20c232b AS jq
+ FROM ghcr.io/jqlang/jq:1.7.1 AS jq
```

Looks like `us-docker.pkg.dev/appintegration-toolkit/internal/jq` does not allow public access.